### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
             "hype = ofxstatement.plugins.hype:HypePlugin"
         ]
     },
-    install_requires=["ofxstatement"],
+    install_requires=["ofxstatement", "pandas", "tabula-py", "pypdf2"],
     extras_require={"test": ["pytest"]},
     include_package_data=True,
     zip_safe=True,


### PR DESCRIPTION
Installing this package is not as straightforward as it could be by just using `pip install ofxstatement-hype` because of missing dependencies in the setup.py